### PR TITLE
http.Get

### DIFF
--- a/lib/mastodon.go
+++ b/lib/mastodon.go
@@ -60,11 +60,7 @@ func (m MastodonPlugin) MetricKeyPrefix() string {
 // FetchMetrics interface for mackerel plugin
 func (m MastodonPlugin) FetchMetrics() (map[string]interface{}, error) {
 	uri := fmt.Sprintf("https://%s/about/more", m.Host)
-	req, err := http.NewRequest("GET", uri, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := http.Get(uri)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
> [@ykzts](https://pawoo.net/@ykzts) `http.DefaultClient`を勝手に使ってくれる`http.Get`という関数があります。
> 
> [https://github.com/ykzts/mackerel-plugin-mastodon/blob/master/lib/mastodon.go#L63-L67](https://github.com/ykzts/mackerel-plugin-mastodon/blob/f71af84cedd1aeb8a5029548330e3eb92b995622/lib/mastodon.go#L63-L67)
> 
> この辺のコードは `resp, err := http.Get(uri)` で十分だと思います。

cite: https://pawoo.net/@catatsuy/6801240